### PR TITLE
Cleanup; add contentEditable elements to blacklist

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -5,7 +5,8 @@ const tagBlacklist = [
     'select',
     'option',
     'datalist',
-    'keygen'
+    'keygen',
+    '[contenteditable]'
 ];
 
 const matches = /Chrome\/([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/.exec(navigator.userAgent);

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,12 +1,12 @@
-// List of tags that, when active, mean the page shouldn't go back.
-const tagBlacklist = {
-    'input': true,
-    'textarea': true,
-    'select': true,
-    'option': true,
-    'datalist': true,
-    'keygen': true
-};
+// List of selectors that, when focused on, mean the page shouldn't go back.
+const tagBlacklist = [
+    'input',
+    'textarea',
+    'select',
+    'option',
+    'datalist',
+    'keygen'
+];
 
 const matches = /Chrome\/([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/.exec(navigator.userAgent);
 const version = {
@@ -21,16 +21,22 @@ const version = {
 if (version.major > 52 ||
     (version.major === 52 && version.minor > 0) ||
     (version.major === 52 && version.minor === 0 && version.build >= 2720)) {
-    document.onkeydown = function (event) {
+    document.addEventListener("keydown", function (event) {
         // Check if key pressed was backspace.
-        if (event.keyCode === 8) {
-            // Get the HTML tag name of the active element.
-            let activeTag = document.activeElement.tagName.toLowerCase();
-
-            // Check to see if the user has focus on a form element.
-            if (!tagBlacklist.hasOwnProperty(activeTag)) {
+        if (event.key === "Backspace") {
+            // Get the active element.
+            let activeEl = document.activeElement;
+            let activateBack = true;
+            
+            // Check to see if the user has focus on a blacklisted element.
+            tagBlacklist.forEach(function(selector) {
+                if (activeEl.matches(selector))
+                    activateBack = false;
+            });
+            
+            if (activateBack) {
                 history.go(-1);
             }
         }
-    };
+    }, false);
 }


### PR DESCRIPTION
I noticed that contenteditables wouldn't count as being "input" elements, so this fixes that. To add contenteditables, I had to convert tagBlacklist to a selector list. (I also couldn't resist cleaning up a bit along the way.)