### PR TITLE
Fixed behavior on sites like Google Search

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Back to Backspace",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "manifest_version": 2,
   "description": "Use backspace to go back to the previous page you were on.",
   "homepage_url": "https://github.com/j-delaney/back-to-backspace",

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -53,6 +53,6 @@ if (version.major > 52 ||
             }
         }
     }, true); // Sites like Google Search move you to the input field when
-              // backspace is pressed. The `true` couses the script to be
+              // backspace is pressed. The `true` causes the script to be
               // executed before Google does its thing.
 }

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -28,14 +28,21 @@ if (version.major > 52 ||
             // Get the active element.
             let activeEl = document.activeElement;
             let activateBack = true;
-            
+
             // Check to see if the user has focus on a blacklisted element.
             tagBlacklist.forEach(function(selector) {
                 if (activeEl.matches(selector))
                     activateBack = false;
             });
-            
+
             if (activateBack) {
+                // If backspace is pressed on a site like Google Search, Google
+                // will move the focus to the input field. Causing you to see
+                // the last character of the input field to be removed before
+                // going back (or forward) a page.
+                // This disables that behavior.
+                event.stopImmediatePropagation();
+
                 if (event.shiftKey) {
                     // Go forward in history if the shift key is being held down.
                     history.go(1);
@@ -45,5 +52,7 @@ if (version.major > 52 ||
                 }
             }
         }
-    }, false);
+    }, true); // Sites like Google Search move you to the input field when
+              // backspace is pressed. The `true` couses the script to be
+              // executed before Google does its thing.
 }


### PR DESCRIPTION
If backspace is pressed on a site like Google Search, Google
will move the focus to the input field. Which cancels the moving back
(or forward) even if the input element was not selected when the back
key was pressed.
This disables that behavior.