### PR TITLE
replace browser sniffing with manifest field

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "manifest_version": 2,
   "description": "Use backspace to go back to the previous page you were on.",
   "homepage_url": "https://github.com/j-delaney/back-to-backspace",
+  "minimum_chrome_version": "52",
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -8,40 +8,26 @@ const tagBlacklist = [
     'keygen'
 ];
 
-const matches = /Chrome\/([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/.exec(navigator.userAgent);
-const version = {
-    major: Number(matches[1]),
-    minor: Number(matches[2]),
-    build: Number(matches[3]),
-    patch: Number(matches[4])
-};
+document.addEventListener("keydown", function (event) {
+    // Check if key pressed was backspace.
+    if (event.key === "Backspace" || event.keyCode == 8) {
+        // Get the active element.
+        // Check to see if the user has focus on a blacklisted element.
+        if ( tagBlacklist.indexOf(document.activeElement.nodeName.toLowerCase()) === -1
+          && document.activeElement.contentEditable !== "true"
+          && document.activeElement.contentEditable !== "plaintext-only") {
+            // If backspace is pressed on a site like Google Search, Google
+            // will move the focus to the input field. Causing you to see
+            // the last character of the input field to be removed before
+            // going back (or forward) a page.
+            // This disables that behavior.
+            event.stopImmediatePropagation();
 
-// If the user is at or above the minimum version (52.0.2720.0) then active the extension.
-// I know this section is messy. It needs to be rewritten.
-if (version.major > 52 ||
-    (version.major === 52 && version.minor > 0) ||
-    (version.major === 52 && version.minor === 0 && version.build >= 2720)) {
-    document.addEventListener("keydown", function (event) {
-        // Check if key pressed was backspace.
-        if (event.key === "Backspace" || event.keyCode == 8) {
-            // Get the active element.
-            // Check to see if the user has focus on a blacklisted element.
-            if ( tagBlacklist.indexOf(document.activeElement.nodeName.toLowerCase()) === -1
-              && document.activeElement.contentEditable !== "true"
-              && document.activeElement.contentEditable !== "plaintext-only") {
-                // If backspace is pressed on a site like Google Search, Google
-                // will move the focus to the input field. Causing you to see
-                // the last character of the input field to be removed before
-                // going back (or forward) a page.
-                // This disables that behavior.
-                event.stopImmediatePropagation();
-
-                // Go forward in history if the shift key is being held down.
-                // Go backwards in history if the shift key is not being held down.
-                history.go( event.shiftKey ? 1 : -1 );
-            }
+            // Go forward in history if the shift key is being held down.
+            // Go backwards in history if the shift key is not being held down.
+            history.go( event.shiftKey ? 1 : -1 );
         }
-    }, true); // Sites like Google Search move you to the input field when
-              // backspace is pressed. The `true` causes the script to be
-              // executed before Google does its thing.
-}
+    }
+}, true); // Sites like Google Search move you to the input field when
+          // backspace is pressed. The `true` causes the script to be
+          // executed before Google does its thing.


### PR DESCRIPTION
The [Chrome Extension manifest](https://developer.chrome.com/extensions/manifest) has an optional field called "minimum_chrome_version". With that set, Chrome will allow the extension to be installed and run only on versions equal and above the given value.

This PR replaces Chrome version sniffing with the manifest field. 
Cleaner code ;)
